### PR TITLE
[WIP] Fix RemoteTreeViewer CMake and compiler errors on Ubuntu 16.04 with clang

### DIFF
--- a/src/RemoteTreeViewer/RemoteTreeViewerWrapper.cpp
+++ b/src/RemoteTreeViewer/RemoteTreeViewerWrapper.cpp
@@ -271,7 +271,7 @@ void RemoteTreeViewerWrapper::publishGeometry(const Geometry& geometry, Affine3d
       }
       break;
     default:
-      cout << "Unsupported geometry type " << geometry.getShape() << ", sorry!" << cout;
+      cout << "Unsupported geometry type " << geometry.getShape() << ", sorry!" << endl;
       return;
   }
 


### PR DESCRIPTION
WIP: **DO NOT MERGE**

This is a work-in-progress to address #24.
The above source code fix only helps on other branches, but still does not work off of `master` / `feature/tri_ubuntu_16_04_clang`.