### PR TITLE
Add options to select drake-iiwa-driver repo in superbuild.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,11 +150,20 @@ endif()
 
 if (WITH_DRIVERS)
 
+  set(IIWA_DRIVER_GIT_REPOSITORY
+	"git@github.com:RobotLocomotion/drake-iiwa-driver.git"
+	CACHE STRING
+	"Location of drake-iiwa-driver repo including kuka-fri sources")
+  set(IIWA_DRIVER_GIT_TAG
+	"19e20aa"
+	CACHE STRING
+	"Build tag of drake-iiwa-driver repo")
+
   ExternalProject_Add(drake-iiwa-driver
     SOURCE_DIR ${build_dir}/externals/drake-iiwa-driver
     BINARY_DIR ${build_dir}/drake-iiwa-driver
-    GIT_REPOSITORY git@github.com:RobotLocomotion/drake-iiwa-driver.git
-    GIT_TAG 19e20aa
+    GIT_REPOSITORY "${IIWA_DRIVER_GIT_REPOSITORY}"
+    GIT_TAG "${IIWA_DRIVER_GIT_TAG}"
     BUILD_ALWAYS 1
     CMAKE_CACHE_ARGS
       -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_INSTALL_PREFIX}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,11 @@ configure_file(config/setup_environment.sh.in ${CMAKE_BINARY_DIR}/setup_environm
 
 # Options
 option(WITH_PERCEPTION "Build with perception libraries and tools." ON)
-option(WITH_DRIVERS "Build the hardware lcm driver." OFF)
+
+option(WITH_IIWA_DRIVER "Build drake-iiwa-driver." OFF)
+option(WITH_SCHUNK_DRIVER "Build drake-schunk-driver." OFF)
+option(WITH_OPTITRACK_DRIVER "Build optitrack-driver." OFF)
+
 option(BUILD_GYGES "Build the GYGES external project" OFF)
 option(USE_SYSTEM_VTK "Use system VTK for drake and director." OFF)
 
@@ -148,7 +152,7 @@ if (OFF)
 
 endif()
 
-if (WITH_DRIVERS)
+if (WITH_IIWA_DRIVER)
 
   set(IIWA_DRIVER_GIT_REPOSITORY
 	"git@github.com:RobotLocomotion/drake-iiwa-driver.git"
@@ -171,6 +175,10 @@ if (WITH_DRIVERS)
     DEPENDS drake
   )
 
+endif()
+
+if (WITH_SCHUNK_DRIVER)
+
   ExternalProject_Add(drake-schunk-driver
     SOURCE_DIR ${build_dir}/externals/drake-schunk-driver
     GIT_REPOSITORY git@github.com:RobotLocomotion/drake-schunk-driver.git
@@ -182,6 +190,10 @@ if (WITH_DRIVERS)
     INSTALL_COMMAND ""
     DEPENDS drake
   )
+
+endif()
+
+if (WITH_OPTITRACK_DRIVER)
 
   ExternalProject_Add(optitrack-driver
     SOURCE_DIR ${build_dir}/externals/optitrack-driver

--- a/README.rst
+++ b/README.rst
@@ -55,9 +55,9 @@ By default, cmake generates a Makefile, but it's possible to use other
 build tools like ninja.
 
 Building With Drivers
-------------------------
+---------------------
 Spartan has CMake options to build `WITH_*_DRIVER`, which add various
-proprietary drivers to the build. This following drivers and their
+proprietary drivers to the build. The following drivers and their
 corresponding flags are supported:
 
 * `WITH_IIWA_DRIVER`: [`drake-iiwa-driver`](https://github.com/RobotLocomotion/drake-iiwa-driver)
@@ -73,27 +73,27 @@ the `kuka-fri` proprietary driver. The `drake-iiwa-driver` by default pulls this
 as a submodule from the private RobotLocomotion kuka-fri repo. To build against
 a different version, follow these steps:
 
-1. Clone `drake-iiwa-driver` to your local machine:
+1. Clone `drake-iiwa-driver` to your local machine::
 
-        git clone https://github.com/RobotLocomotion/drake-iiwa-driver
+    git clone https://github.com/RobotLocomotion/drake-iiwa-driver
 
-1. Delete the kuka-fri submodule.
+2. Delete the kuka-fri submodule.
 
         cd drake-iiwa-driver
         git rm kuka-fri
 
-1. Extract your copy of the kuka drivers, and apply patches according to the
+3. Extract your copy of the kuka drivers, and apply patches according to the
 instruction in [`drake-iiwa-driver/README.md`](https://github.com/RobotLocomotion/drake-iiwa-driver/blob/master/README.md).
 
-1. Commit the changes and note the commit hash.
+4. Commit the changes and note the commit hash.
 
-1. In Spartan build directory, enable `WITH_IIWA_DRIVER` and reconfigure CMake.
+5. In Spartan build directory, enable `WITH_IIWA_DRIVER` and reconfigure CMake.
 Two additional options will appear:
    * `IIWA_DRIVER_GIT_REPOSITORY`: Set to the clone of address for your local
       `drake-iiwa-driver`. For example, `file:///home/example/drake-iiwa-driver/`
    * `IIWA_DRIVER_GIT_TAG`: The (short) commit hash from above. For example, `a1b2c34`
 
-1. Reconfigure CMake once more, and build.
+6. Reconfigure CMake once more, and build.
 
         cd spartan/build
         cmake ..

--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,52 @@ Finally, run the build::
 By default, cmake generates a Makefile, but it's possible to use other
 build tools like ninja.
 
+Building With Drivers
+------------------------
+Spartan has CMake options to build `WITH_*_DRIVER`, which add various
+proprietary drivers to the build. This following drivers and their
+corresponding flags are supported:
+
+* `WITH_IIWA_DRIVER`: [`drake-iiwa-driver`](https://github.com/RobotLocomotion/drake-iiwa-driver)
+* `WITH_SCHUNK_DRIVER`: `drake-schunk-driver`
+* `WITH_OPTITRACK_DRIVER`: [`optitrack-driver`](https://github.com/sammy-tri/optitrack-driver)
+
+Unless you are a member of the RobotLocomotion team, you will likely not have
+access required to build all the above libraries and should these options
+disabled.
+
+There is a workaround for building `drake-iiwa-driver` using a local version of
+the `kuka-fri` proprietary driver. The `drake-iiwa-driver` by default pulls this in
+as a submodule from the private RobotLocomotion kuka-fri repo. To build against
+a different version, follow these steps:
+
+1. Clone `drake-iiwa-driver` to your local machine:
+
+        git clone https://github.com/RobotLocomotion/drake-iiwa-driver
+
+1. Delete the kuka-fri submodule.
+
+        cd drake-iiwa-driver
+        git rm kuka-fri
+
+1. Extract your copy of the kuka drivers, and apply patches according to the
+instruction in [`drake-iiwa-driver/README.md`](https://github.com/RobotLocomotion/drake-iiwa-driver/blob/master/README.md).
+
+1. Commit the changes and note the commit hash.
+
+1. In Spartan build directory, enable `WITH_IIWA_DRIVER` and reconfigure CMake.
+Two additional options will appear:
+   * `IIWA_DRIVER_GIT_REPOSITORY`: Set to the clone of address for your local
+      `drake-iiwa-driver`. For example, `file:///home/example/drake-iiwa-driver/`
+   * `IIWA_DRIVER_GIT_TAG`: The (short) commit hash from above. For example, `a1b2c34`
+
+1. Reconfigure CMake once more, and build.
+
+        cd spartan/build
+        cmake ..
+        make
+
+
 Common Build Errors
 -------------------
 


### PR DESCRIPTION
As discussed in #117, this change adds options to the superbuild cache for a user to select where their drake-iiwa-driver repo is located. Currently, the best solution to building with proprietary drivers is to clone drake-iiwa-driver, insert private drivers on a local commit, and point the superbuild to the correct location.

For example, after adding the proprietary drivers on a local clone, I would use a CMake GUI to set the following options:

IIWA_DRIVER_GIT_REPOSITORY = "file:///home/momap/workspace/drake-iiwa-driver/"
IIWA_DRIVER_GIT_TAG = "1a2b3c4"

Upon rebuild, the local driver repository will be pulled instead of the upstream, and there should be no errors due to denied access.