### PR TITLE
Adds a terminator config file to the docker

### DIFF
--- a/setup/docker/spartan.dockerfile
+++ b/setup/docker/spartan.dockerfile
@@ -11,4 +11,7 @@ RUN yes "Y" | /tmp/spartan_install_prereqs.sh
 COPY ./drake/setup/ubuntu/16.04/install_prereqs.sh /tmp/drake_install_prereqs.sh
 RUN yes "Y" | /tmp/drake_install_prereqs.sh
 
+RUN mkdir -p /root/.config/terminator
+COPY ./setup/docker/terminator_config /root/.config/terminator/config
+
 ENTRYPOINT bash -c "source /root/spartan/setup/docker/entrypoint.sh && /bin/bash"

--- a/setup/docker/terminator_config
+++ b/setup/docker/terminator_config
@@ -1,0 +1,16 @@
+# Modified terminator default config
+# for use in Spartan docker container
+[global_config] 
+  focus = system
+
+[keybindings] 
+  full_screen = <Ctrl><Shift>F11
+
+
+[profiles] 
+  [[default]] 
+    font = Fixed 10 
+    background_color = "#501010" # A comment 
+    foreground_color = "#FFFFFF" # Note that hex colour values must be quoted
+    scrollback_lines = '4000' #More comment. Single quotes are valid too
+    cursor_blink = True

--- a/setup/docker/terminator_config
+++ b/setup/docker/terminator_config
@@ -6,11 +6,9 @@
 [keybindings] 
   full_screen = <Ctrl><Shift>F11
 
-
 [profiles] 
-  [[default]] 
-    font = Fixed 10 
-    background_color = "#501010" # A comment 
-    foreground_color = "#FFFFFF" # Note that hex colour values must be quoted
-    scrollback_lines = '4000' #More comment. Single quotes are valid too
-    cursor_blink = True
+  [[default]] # solarized-light
+	palette = "#073642:#dc322f:#859900:#b58900:#268bd2:#d33682:#2aa198:#eee8d5:#002b36:#cb4b16:#586e75:#657b83:#839496:#6c71c4:#93a1a1:#fdf6e3"
+	foreground_color = "#eee8d5"
+	background_color = "#002b36"
+	cursor_color = "#eee8d5"


### PR DESCRIPTION
With default coloring of red background, which distinguishes it from the black background
of the default terminatorconfig on iiwa-workstation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/spartan/136)
<!-- Reviewable:end -->
