### PR TITLE
Add tmux and nano to docker default utilities

### DIFF
--- a/setup/docker/install_dependencies.sh
+++ b/setup/docker/install_dependencies.sh
@@ -5,5 +5,6 @@ set -euxo pipefail
 apt-get update
 apt install --no-install-recommends \
   terminator \
+  tmux \
   git \
   openssh-client

--- a/setup/docker/install_dependencies.sh
+++ b/setup/docker/install_dependencies.sh
@@ -6,5 +6,6 @@ apt-get update
 apt install --no-install-recommends \
   terminator \
   tmux \
+  nano \
   git \
   openssh-client


### PR DESCRIPTION
Alongside terminator, as a choice to run multiple terminals within the docker container. The tmux route has less floating terminal window bloat than terminator (which opens a new floating window rather than given a multiplex'd terminal inside of the existing terminal), and I generally find really useful for running larger numbers of processes.

This can be delayed until it's convenient to merge (since it will make the next docker_build really long) but I'd appreciate not having to apt-get install it every time!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/spartan/144)
<!-- Reviewable:end -->
