### PR TITLE
Drake build in docker persists in carefully-named home directory on host

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ else()
   set(BAZEL_COMPILATION_MODE opt)
 endif()
 set(BAZEL_ENV CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER})
+set(BAZEL_DRAKE_STARTUP_ARGS "--output_base=/$ENV{HOME}/.spartan-build/drake-build")
 set(BAZEL_ARGS --compilation_mode=${BAZEL_COMPILATION_MODE} --config=unsupported_crosstool --cxxopt=-std=c++1y --host_cxxopt=-std=c++1y)
 if(CMAKE_VERBOSE_MAKEFILE)
   set(BAZEL_ARGS --subcommands ${BAZEL_ARGS})
@@ -106,8 +107,8 @@ ExternalProject_Add(drake
     BUILD_IN_SOURCE 1
     USES_TERMINAL_BUILD 1
     CONFIGURE_COMMAND ""
-    BUILD_COMMAND ${BAZEL_ENV} "${BAZEL}" build ${BAZEL_ARGS} //drake/examples/kuka_iiwa_arm/... //:install @optitrack_driver//src:optitrack_client
-    INSTALL_COMMAND ${BAZEL_ENV} "${BAZEL}" run ${BAZEL_ARGS} //:install -- "${CMAKE_INSTALL_PREFIX}"
+    BUILD_COMMAND ${BAZEL_ENV} "${BAZEL}" ${BAZEL_DRAKE_STARTUP_ARGS} build ${BAZEL_ARGS} //drake/examples/kuka_iiwa_arm/... //:install @optitrack_driver//src:optitrack_client
+    INSTALL_COMMAND ${BAZEL_ENV} "${BAZEL}" ${BAZEL_DRAKE_STARTUP_ARGS} run ${BAZEL_ARGS} //:install -- "${CMAKE_INSTALL_PREFIX}"
 )
 # This is based on drake's VTK/Qt dependency (see `tools/vtk.bzl` in drake).
 # On MacOS, Drake uses homebrew VTK compiled with Qt5 and brew Python

--- a/setup/docker/docker_run.py
+++ b/setup/docker/docker_run.py
@@ -31,6 +31,15 @@ if __name__=="__main__":
 	cmd += " -v %(source_dir)s:%(home_directory)s/spartan "  \
 		% {'source_dir': source_dir, 'home_directory': home_directory}	            # mount source
 	cmd += " -v ~/.ssh:%(home_directory)s/.ssh " % {'home_directory': home_directory}   # mount ssh keys
+
+	# Make Bazel artifact dir if it doesn't exist
+	bazel_artifact_dir = "~/.spartan-docker/%(image_name)s-build" % {'image_name': image_name}
+	mkdir_cmd = "mkdir -p %s" % bazel_artifact_dir
+	print "command = ", mkdir_cmd
+	os.system(mkdir_cmd)
+
+	cmd += " -v %(bazel_artifact_dir)s:%(home_directory)s/.spartan-build " \
+	% {'bazel_artifact_dir': bazel_artifact_dir, 'home_directory': home_directory}   # mount bazel build artifact dirs
 	cmd += " --user %s " % user_name                                                    # login as current user
 
     # expose UDP ports


### PR DESCRIPTION
Creates a directory `~/.spartan-docker/<spartan docker image name>` on the host, and links it to the `~/.spartan-build/` directory in the docker container. Drake build is configured to keep build artifacts from bazel in `~/.spartan-build/drake-build`. When other builds turn to Bazel too, they can be configured similarly to keep artifacts in that folder.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/spartan/157)
<!-- Reviewable:end -->
