### PR TITLE
Install schunk driver with reasonable permissions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,7 +272,9 @@ if (WITH_SCHUNK_DRIVER)
     USES_TERMINAL_BUILD 1
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ${BAZEL_ENV} "${BAZEL}" build //...
-    INSTALL_COMMAND "${CP}" ${build_dir}/externals/drake-schunk-driver/bazel-bin/src/schunk_driver ${build_dir}/install/bin/
+    INSTALL_COMMAND
+      "${CP}" ${build_dir}/externals/drake-schunk-driver/bazel-bin/src/schunk_driver ${build_dir}/install/bin/ &&
+      chmod ug+w ${build_dir}/install/bin/schunk_driver
     DEPENDS drake
   )
 


### PR DESCRIPTION
Address #159. Underlying cause appears to be that the bazel-generated file has no write permissions at all... this works around that, though we ought to help fix up that bazel build to have a real install rule instead, eventually.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/spartan/162)
<!-- Reviewable:end -->
