### PR TITLE
Async run through calibration with threads via TaskRunner module from @patmarion

### DIFF
--- a/modules/spartan/perception/handeyecalibration.py
+++ b/modules/spartan/perception/handeyecalibration.py
@@ -43,7 +43,7 @@ from spartan.taskrunner import TaskRunner
 To run this set useKukaRLGDev to True in iiwaManipApp.py. This loads a
 HandEyeCalibration object into the director workspace, it is called cal.
 
-To run calibration simply press F8 and enter cal.runCalibration(). This creates a new directory
+To run calibration simply press F8 and enter cal.runThreaded(). This creates a new directory
 in spartan/calibration_data which contains two files.
 
 calibration.lcmlog: a log of the run

--- a/modules/spartan/taskrunner.py
+++ b/modules/spartan/taskrunner.py
@@ -1,0 +1,48 @@
+import sys
+import time
+import sys
+from threading import Thread
+
+from director import asynctaskqueue
+from director.timercallback import TimerCallback
+
+
+class TaskRunner(object):
+
+  def __init__(self):
+    self.interval = 1/60.0
+    sys.setcheckinterval(1000)
+    #sys.setswitchinterval(self.interval)			# sys.setswitchinterval is only Python 3
+    self.task_queue = asynctaskqueue.AsyncTaskQueue()
+    self.pending_tasks = []
+    self.threads = []
+    self.timer = TimerCallback(callback=self._on_timer)
+
+  def _on_timer(self):
+    time.sleep(self.interval)
+    if self.pending_tasks:
+      while True:
+        try:
+          self.task_queue.addTask(self.pending_tasks.pop(0))
+        except IndexError:
+          break
+
+      if self.task_queue.tasks and not self.task_queue.isRunning:
+        self.task_queue.start()
+
+    for t in self.threads:
+      if t.is_alive():
+        break
+    else:
+      self.threads = []
+      self.timer.stop()
+
+  def call_on_main(self, func, *args, **kwargs):
+    self.pending_tasks.append(lambda: func(*args, **kwargs))
+
+  def call_on_thread(self, func, *args, **kwargs):
+    t = Thread(target=lambda: func(*args, **kwargs))
+    self.threads.append(t)
+    t.start()
+    self.timer.targetFps = 1/self.interval
+    self.timer.start()


### PR DESCRIPTION
This PR brings in the TaskRunner class (written by @patmarion -- thanks Pat!) in as a Spartan module.  Can later see if can get this module to live in Director.

It is very useful for wrapping a simple, very readable run of blocking code (written by @manuelli) that operates the calibration step by step.

Calibration now suggested to be started via `cal.runThreaded()`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/spartan/164)
<!-- Reviewable:end -->
