### PR TITLE
fix bugs in taskrunner

### DIFF
--- a/apps/iiwa/iiwaManipApp.py
+++ b/apps/iiwa/iiwaManipApp.py
@@ -336,6 +336,8 @@ applogic.resetCamera(viewDirection=[-1,1,-0.5], view=view)
 useKukaRLGDev = False
 if useKukaRLGDev:
 
+
+
     # broadcast the pose of the wrist mounted Xtion
     import spartan.utils as spartanUtils
     cameraConfigFilename = os.path.join(spartanUtils.getSpartanSourceDir(), 'config', 'RLG', 'iiwa_1', 'camera_config.yaml')
@@ -347,3 +349,14 @@ if useKukaRLGDev:
 
     import spartan.perception.handeyecalibration
     cal = spartan.perception.handeyecalibration.HandEyeCalibration(robotSystem)
+
+def testFunction():
+    print "sleeping for 5 seconds"
+    time.sleep(5.0)
+    print "finished testFunction"
+
+from spartan import taskrunner
+from spartan import taskrunnerold
+
+taskRunner = taskrunner.TaskRunner()
+taskRunnerOld = taskrunnerold.TaskRunner()

--- a/apps/iiwa/iiwaManipApp.py
+++ b/apps/iiwa/iiwaManipApp.py
@@ -336,8 +336,6 @@ applogic.resetCamera(viewDirection=[-1,1,-0.5], view=view)
 useKukaRLGDev = False
 if useKukaRLGDev:
 
-
-
     # broadcast the pose of the wrist mounted Xtion
     import spartan.utils as spartanUtils
     cameraConfigFilename = os.path.join(spartanUtils.getSpartanSourceDir(), 'config', 'RLG', 'iiwa_1', 'camera_config.yaml')
@@ -349,14 +347,3 @@ if useKukaRLGDev:
 
     import spartan.perception.handeyecalibration
     cal = spartan.perception.handeyecalibration.HandEyeCalibration(robotSystem)
-
-def testFunction():
-    print "sleeping for 5 seconds"
-    time.sleep(5.0)
-    print "finished testFunction"
-
-from spartan import taskrunner
-from spartan import taskrunnerold
-
-taskRunner = taskrunner.TaskRunner()
-taskRunnerOld = taskrunnerold.TaskRunner()

--- a/modules/spartan/perception/handeyecalibration.py
+++ b/modules/spartan/perception/handeyecalibration.py
@@ -109,7 +109,7 @@ class HandEyeCalibration(object):
 
 		self.timer = TimerCallback(targetFps=1)
 		self.timer.callback = self.callback
-		self.task_runner = TaskRunner()
+		self.taskRunner = TaskRunner()
         # self.timer.callback = self.callback
 
 	def setup(self):
@@ -152,7 +152,7 @@ class HandEyeCalibration(object):
 		self.robotService.movePose(self.poseDict['center']['nominal'])
 
 	def runThreaded(self):
-		self.task_runner.call_on_thread(self.run)
+		self.taskRunner.callOnThread(self.run)
 
 	def run(self):
 		self.calibrationData = []

--- a/modules/spartan/taskrunner.py
+++ b/modules/spartan/taskrunner.py
@@ -16,7 +16,7 @@ class TaskRunner(object):
     self.taskQueue = asynctaskqueue.AsyncTaskQueue()
     self.pendingTasks = []
     self.threads = []
-    self.timer = TimerCallback(callback=self._onTimer)
+    self.timer = TimerCallback(callback=self._onTimer, targetFps=1/self.interval)
 
   def _onTimer(self):
     # Give up control to another python thread in self.threads
@@ -56,5 +56,4 @@ class TaskRunner(object):
     t = Thread(target=lambda: func(*args, **kwargs))
     self.threads.append(t)
     t.start()
-    self.timer.targetFps = 1/self.interval
     self.timer.start()


### PR DESCRIPTION
- `call_on_main` used to have no effect because timer was never started
- fix cleaning up of stale threads and starting/stopping the timer.
- switch to camel case
- switch handeyecalibration to use the API with camel case

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/spartan/167)
<!-- Reviewable:end -->
