### PR TITLE
Add convex decomposition utility (v-hacd + trimesh)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,7 +254,7 @@ if (WITH_TRIMESH)
     endif()
 
     SET(TRIMESH_GIT_REPOSITORY git@github.com:gizatt/trimesh.git)
-    SET(TRIMESH_GIT_TAG 09694bd22bd6e0ed2a0569e5dd8f60daa5568f73)
+    SET(TRIMESH_GIT_TAG b991f6ec29252272d38cfb33af927adf7681a66e)
     # Installs our customized version of trimesh
     # to the project's site-packages build folder.
     # I use the setup.py to run the build step,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ option(WITH_IIWA_DRIVER_TRI "Build drake-iiwa-driver, TRI version." OFF)
 option(WITH_SCHUNK_DRIVER "Build drake-schunk-driver." OFF)
 option(WITH_ROS "Build the catkin-workspace projects." OFF)
 option(WITH_REACHABILITY_ANALYZER "Build a reachability analyzer (better with snopt)" OFF)
+option(WITH_TRIMESH "Build trimesh, a python utility for working with triangle meshes" OFF)
 
 # Setup external projects
 include(ExternalProject)
@@ -227,6 +228,49 @@ if (WITH_REACHABILITY_ANALYZER)
     ${CMAKE_ARGS_FOR_EXTERNALS}
   DEPENDS drake director RemoteTreeViewer common_utils
   )
+endif()
+
+if (WITH_TRIMESH)
+    find_package(PythonInterp REQUIRED)
+
+    # Grab and copy in the v-hacd executable
+    # (which is precompiled for ubuntu 16.04
+    # on this branch)
+    if (UNIX AND NOT APPLE)
+      SET(VHACD_GIT_REPOSITORY git@github.com:mikedh/v-hacd-1.git)
+      SET(VHACD_GIT_TAG e3acd8637397fab37423c734c6a980d7031d772f)
+      ExternalProject_Add(v-hacd
+        SOURCE_DIR ${build_dir}/externals/v-hacd
+        BINARY_DIR ${build_dir}/v-hacd
+        GIT_REPOSITORY "${VHACD_GIT_REPOSITORY}"
+        GIT_TAG "${VHACD_GIT_TAG}"
+        BUILD_ALWAYS 1
+        CONFIGURE_COMMAND ""
+        BUILD_COMMAND ""
+        INSTALL_COMMAND cp ${build_dir}/externals/v-hacd/bin/linux/testVHACD ${CMAKE_INSTALL_PREFIX}/bin
+      )
+    else()
+      message(FATAL_ERROR "Not using linux, don't know how to install v-hacd.")
+    endif()
+
+    SET(TRIMESH_GIT_REPOSITORY git@github.com:gizatt/trimesh.git)
+    SET(TRIMESH_GIT_TAG 09694bd22bd6e0ed2a0569e5dd8f60daa5568f73)
+    # Installs our customized version of trimesh
+    # to the project's site-packages build folder.
+    # I use the setup.py to run the build step,
+    # but do the module installation manually,
+    # as it was giving me trouble...
+    ExternalProject_Add(trimesh
+      SOURCE_DIR ${build_dir}/externals/trimesh
+      CONFIGURE_COMMAND ""
+      GIT_REPOSITORY "${TRIMESH_GIT_REPOSITORY}"
+      GIT_TAG "${TRIMESH_GIT_TAG}"
+      BUILD_ALWAYS 1
+      BUILD_COMMAND python setup.py build
+      INSTALL_COMMAND cp -r ${build_dir}/externals/trimesh/build/lib.linux-x86_64-2.7/trimesh ${CMAKE_INSTALL_PREFIX}/lib/python2.7/site-packages/
+      BUILD_IN_SOURCE 1
+      DEPENDS v-hacd
+    )
 endif()
 
 if (OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,7 +254,7 @@ if (WITH_TRIMESH)
     endif()
 
     SET(TRIMESH_GIT_REPOSITORY git@github.com:gizatt/trimesh.git)
-    SET(TRIMESH_GIT_TAG b991f6ec29252272d38cfb33af927adf7681a66e)
+    SET(TRIMESH_GIT_TAG aa5e411a9a8a371b67bba7dc93ab0af206d31b77)
     # Installs our customized version of trimesh
     # to the project's site-packages build folder.
     # I use the setup.py to run the build step,
@@ -263,8 +263,8 @@ if (WITH_TRIMESH)
     ExternalProject_Add(trimesh
       SOURCE_DIR ${build_dir}/externals/trimesh
       CONFIGURE_COMMAND ""
-      GIT_REPOSITORY "${TRIMESH_GIT_REPOSITORY}"
-      GIT_TAG "${TRIMESH_GIT_TAG}"
+      #GIT_REPOSITORY "${TRIMESH_GIT_REPOSITORY}"
+      #GIT_TAG "${TRIMESH_GIT_TAG}"
       BUILD_ALWAYS 1
       BUILD_COMMAND python setup.py build
       INSTALL_COMMAND cp -r ${build_dir}/externals/trimesh/build/lib.linux-x86_64-2.7/trimesh ${CMAKE_INSTALL_PREFIX}/lib/python2.7/site-packages/

--- a/modules/spartan/utils/decompose_mesh_to_urdf.py
+++ b/modules/spartan/utils/decompose_mesh_to_urdf.py
@@ -26,9 +26,20 @@ from trimesh.io.urdf import *
 
 def do_convex_decomposition_to_urdf(obj_filename, obj_mass, output_directory, do_visualization=False, **kwargs):
   mesh = trimesh.load(obj_filename)
+  
+  if (do_visualization):
+    print("\n\nShowing input mesh...")
+    mesh.show()
+
   mesh.density = obj_mass / mesh.volume
   decomposed_mesh = export_urdf(mesh, output_directory, **kwargs)
+  
+
+  print("Input mesh had ", len(mesh.faces), " faces and ", len(mesh.vertices), " verts")
+  print("Output mesh has ", len(decomposed_mesh.faces), " faces and ", len(decomposed_mesh.vertices), " verts")
+
   if (do_visualization):
+    print("\n\nShowing output mesh...")
     decomposed_mesh.show()
 
 if __name__ == "__main__":

--- a/modules/spartan/utils/decompose_mesh_to_urdf.py
+++ b/modules/spartan/utils/decompose_mesh_to_urdf.py
@@ -1,3 +1,22 @@
+'''
+
+Uses v-hacd (https://github.com/kmammou/v-hacd)
+wrapped by trimesh (https://github.com/mikedh/trimesh)
+to perform convex decomposition of a supplied mesh, and
+write the results to a set of .obj meshes, plus a URDF
+binding them all together into a single rigid body.
+
+Invocation:
+
+python -m spartan.utils.decompose_mesh_to_urdf \
+  <input mesh> <input mesh mass> <output directory name>
+  <whether to visualize?> <optional vhacd arguments>
+
+Optional vhacd arguments are currently:
+  --maxhulls
+  --maxNumVerticesPerCH
+
+'''
 
 import argparse
 import sys

--- a/modules/spartan/utils/decompose_mesh_to_urdf.py
+++ b/modules/spartan/utils/decompose_mesh_to_urdf.py
@@ -5,10 +5,10 @@ import sys
 import trimesh
 from trimesh.io.urdf import *
 
-def do_convex_decomposition_to_urdf(obj_filename, obj_mass, output_directory, do_visualization=False):
+def do_convex_decomposition_to_urdf(obj_filename, obj_mass, output_directory, do_visualization=False, **kwargs):
   mesh = trimesh.load(obj_filename)
   mesh.density = obj_mass / mesh.volume
-  decomposed_mesh = export_urdf(mesh, output_directory)
+  decomposed_mesh = export_urdf(mesh, output_directory, **kwargs)
   if (do_visualization):
     decomposed_mesh.show()
 
@@ -20,7 +20,17 @@ if __name__ == "__main__":
   parser.add_argument('mass', help="Mass of the original mesh file.", type=float)
   parser.add_argument('output_directory', help="Output directory for files and urdf.", default="output")
   parser.add_argument('visualize', help="Whether to visualize", default=False, type=bool)
+  
+  # VHACD forwarded argumnets
+  vhacd_forwared_args = ["maxhulls", "maxNumVerticesPerCH"]
+  parser.add_argument('--maxhulls', help="Maximum convex hulls to produce (default is no limit)", default=None, type=int)
+  parser.add_argument('--maxNumVerticesPerCH', help="Maximum vertices per convex hull (default 64, range 4-1024)", default=None, type=int)
 
   args = parser.parse_args()
 
-  do_convex_decomposition_to_urdf(args.filename, args.mass, args.output_directory, args.visualize)
+  vhacd_forwarded_arg_vals = {}
+  for arg in vhacd_forwared_args:
+    if getattr(args, arg) is not None:
+      vhacd_forwarded_arg_vals[arg] = getattr(args, arg)
+
+  do_convex_decomposition_to_urdf(args.filename, args.mass, args.output_directory, args.visualize, **vhacd_forwarded_arg_vals)

--- a/modules/spartan/utils/decompose_mesh_to_urdf.py
+++ b/modules/spartan/utils/decompose_mesh_to_urdf.py
@@ -1,0 +1,26 @@
+
+import argparse
+import sys
+
+import trimesh
+from trimesh.io.urdf import *
+
+def do_convex_decomposition_to_urdf(obj_filename, obj_mass, output_directory, do_visualization=False):
+  mesh = trimesh.load(obj_filename)
+  mesh.density = obj_mass / mesh.volume
+  decomposed_mesh = export_urdf(mesh, output_directory)
+  if (do_visualization):
+    decomposed_mesh.show()
+
+if __name__ == "__main__":
+  trimesh.util.attach_to_log()
+
+  parser = argparse.ArgumentParser(description = "")
+  parser.add_argument('filename', help="Mesh file to decompose.")
+  parser.add_argument('mass', help="Mass of the original mesh file.", type=float)
+  parser.add_argument('output_directory', help="Output directory for files and urdf.", default="output")
+  parser.add_argument('visualize', help="Whether to visualize", default=False, type=bool)
+
+  args = parser.parse_args()
+
+  do_convex_decomposition_to_urdf(args.filename, args.mass, args.output_directory, args.visualize)

--- a/setup/docker/install_dependencies.sh
+++ b/setup/docker/install_dependencies.sh
@@ -15,4 +15,8 @@ apt install --no-install-recommends \
   libopenni-dev \
   apt-utils \
   usbutils \
-  dialog
+  dialog \
+  python-pip
+
+# Dependencies of trimesh
+pip install numpy scipy pyassimp

--- a/setup/docker/install_dependencies.sh
+++ b/setup/docker/install_dependencies.sh
@@ -19,4 +19,4 @@ apt install --no-install-recommends \
   python-pip
 
 # Dependencies of trimesh
-pip install numpy scipy pyassimp
+pip install numpy scipy pyassimp pyglet

--- a/setup/docker/run_jenkins.sh
+++ b/setup/docker/run_jenkins.sh
@@ -4,7 +4,7 @@ rm -rf build
 mkdir build
 cd build
 
-cmake -DWITH_PERCEPTION:BOOL=ON ..
+cmake -DWITH_PERCEPTION:BOOL=ON -DWITH_TRIMESH:BOOL=ON ..
 exit_status=$?
 if [ ! $exit_status -eq 0 ]; then
   echo "Error code in CMake: " $exit_status


### PR DESCRIPTION
Adds support for some externals that help perform convex decomposition of a mesh into a set of approximately convex meshes, plus a URDF that encodes the decomposed parts' masses, inertias, and relative locations.

PRing for some testing; will update once I test the produced meshes in sim and make sure they don't have glaring issues. For now, pretty pictures:

Example input (with 2448 faces and 1226 verts): 
![image](https://user-images.githubusercontent.com/3066703/33082664-51ca8fa0-ceab-11e7-8f18-acf35591310a.png)

Example output (with 208 faces and 120 verts):
![image](https://user-images.githubusercontent.com/3066703/33082696-640bb8ce-ceab-11e7-869a-8837a2a016d8.png)

Example output (with 926 faces and 493 verts):
![image](https://user-images.githubusercontent.com/3066703/33082862-d32a74c0-ceab-11e7-91e5-3ee9867e331d.png)

Number of convex pieces, and complexity of those pieces, is controllable.

