### PR TITLE
Robot status ROS message time

### DIFF
--- a/src/catkin_projects/robot_server/src/robot_server/pub_joint_state.py
+++ b/src/catkin_projects/robot_server/src/robot_server/pub_joint_state.py
@@ -82,7 +82,12 @@ class JointStatePublisher:
                 self.joint_velocities[idx] = msg.joint_velocity_estimated[data_idx] # TODO(gizatt) See which other fields are valid and add them here
                 self.joint_efforts[idx] = msg.joint_torque_measured[data_idx]
 
-        self.publishROSJointStateMessage(ros_time_converted_from_lcm)
+        # We *should* be using the sunrise cabinet time.
+        # But it's not always well synchronized with our time,
+        # (e.g. at time of writing, it was off by hours and was
+        # messing up the TF server), so for now I'm approximating with
+        # our local system time. -gizatt
+        self.publishROSJointStateMessage(ros_time_now)
 
 
     def run(self):


### PR DESCRIPTION
Right now I'm seeing a constant offset between the ROS time (i.e. system clock on host computer) vs the timestamp coming in from the arm. This breaks the TF server when that time shift puts the arm state in the future (as it refuses to accept TF updates from the future to figure out things like camera frame pose).

This diff patches this, though I think doing better synchronization -- either estimating the offset or using NTP to sync the two. Syler and David (from DRAPER) mentioned yesterday that they're struggling with the same thing, and NTP has sounded tricky to get working correctly on the embedded windows sunrise box. So I like this hack for now...

@peteflorence this is what was causing the point-clouds-dont-show-up problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/spartan/222)
<!-- Reviewable:end -->
