### PR TITLE
kip -- three letters to procman

### DIFF
--- a/scripts/bin/kip
+++ b/scripts/bin/kip
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+use_ros && use_spartan && kuka_iiwa_procman


### PR DESCRIPTION
This reduces the number of keystrokes needed to get to `kuka_iiwa_procman` from about 21 keystrokes down to 4.

Before
```
use_ros # 4/5 keytrokes, plus enter
use_spartan # 4/5 keystrokes, plus enter 
kuka_iiwa_procman # ~9 keystokes, plus enter
# Total: 4.5 + 4.5 + 9, plus 3 enters = 21 keystrokes
```

After
```
kip # 3 keystokes, plus enter
# Total: 4 keystrokes
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/spartan/247)
<!-- Reviewable:end -->
