### PR TITLE
Nice little important fix to install instructions

### DIFF
--- a/setup/docker/README.md
+++ b/setup/docker/README.md
@@ -28,8 +28,7 @@ and then restart your machine.
 ```
 git clone git@github.com:RobotLocomotion/spartan.git
 cd spartan
-git submodule init
-git submodule update
+git submodule update --init --remote
 ./setup/docker/docker_build.py
 ./setup/docker/docker_run.py
 mkdir build && cd build && use_ros && cmake .. && use_spartan && make -j8


### PR DESCRIPTION
`git submodule update --init --remote` will do the work of actually switching the `remote` of submodules

This for example is needed to switch Handical's remote, ElasticFusion's remote, etc, etc

Even though this is just a README change, I'm PRing so everyone can be aware

@manuelli @gizatt

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/spartan/275)
<!-- Reviewable:end -->
