### PR TITLE
fix bug introduced with rgb_only flag, fixed

### DIFF
--- a/src/catkin_projects/fusion_server/src/fusion_server/fusion.py
+++ b/src/catkin_projects/fusion_server/src/fusion_server/fusion.py
@@ -630,7 +630,7 @@ class FusionServer(object):
         image_capture = ImageCapture(rgb_topic, depth_topic, camera_info_topic,
             self.config['camera_frame'], self.config['world_frame'], rgb_encoding='bgr8')
         image_capture.load_ros_bag(bag_filepath)
-        image_capture.process_ros_bag(image_capture.ros_bag, images_dir, rgb_only=True)
+        image_capture.process_ros_bag(image_capture.ros_bag, images_dir, rgb_only=rgb_only)
 
         rospy.loginfo("Finished writing images to disk")
 


### PR DESCRIPTION
I made an `rgb_only` mode for the bag extraction, to help with making videos.

But this fix is needed to make the `rgb_only` flag only be when you want it.

Currently this fix is needed so that data collection on master will work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/spartan/289)
<!-- Reviewable:end -->
