### PR TITLE
Forces pybind11 to usr Python2.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,7 @@ ExternalProject_Add(pybind11
     ${CMAKE_ARGS_FOR_EXTERNALS}
     -DPYBIND11_INSTALL:BOOL=ON
     -DPYBIND11_TEST:BOOL=OFF
+    -DPYBIND11_PYTHON_VERSION:STRING=2.7
 )
 
 ExternalProject_Add(common_utils


### PR DESCRIPTION
Since Spartan only works with Python2.7, we force pybind11 to use
Python2.7. Without this, pybind11 will find the most recent version of
Python on the system which may be Python3.X which is not consistent
with everything else in Spartan using Python2.7 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/spartan/292)
<!-- Reviewable:end -->
