### PR TITLE
streamline drake systems interfaces inside drake_iiwa_sim

### DIFF
--- a/src/catkin_projects/drake_iiwa_sim/include/drake_iiwa_sim/iiwa_qp_inverse_dynamics_controller.h
+++ b/src/catkin_projects/drake_iiwa_sim/include/drake_iiwa_sim/iiwa_qp_inverse_dynamics_controller.h
@@ -21,19 +21,19 @@ class IiwaQpInverseDynamicsController : public systems::LeafSystem<double> {
                                   double control_period = 0.005);
 
   const systems::OutputPort<double>& get_output_port_torque_commanded() const {
-    return this->get_output_port(0);
+    return this->get_output_port(idx_output_port_commanded_torque_);
   }
 
   const systems::InputPortDescriptor<double>& get_input_port_estimated_state() const {
-    return this->get_input_port(0);
+    return this->get_input_port(idx_input_port_estimated_state_);
   }
 
   const systems::InputPortDescriptor<double>& get_input_port_state_reference() const {
-    return this->get_input_port(1);
+    return this->get_input_port(idx_input_port_state_reference_);
   }
 
   const systems::InputPortDescriptor<double>& get_input_port_torque_reference() const {
-    return this->get_input_port(2);
+    return this->get_input_port(idx_input_port_reference_torque_);
   }
 
   void CopyStateOut(const systems::Context<double>& context,
@@ -52,6 +52,10 @@ class IiwaQpInverseDynamicsController : public systems::LeafSystem<double> {
   Eigen::VectorXd kp_;
   Eigen::VectorXd kd_;
   std::unique_ptr<RigidBodyTreed> tree_{nullptr};
+  int idx_input_port_estimated_state_{-1};
+  int idx_input_port_state_reference_{-1};
+  int idx_input_port_reference_torque_{-1};
+  int idx_output_port_commanded_torque_{-1};
 };
 
 }  // namespace kuka_iiwa_arm

--- a/src/catkin_projects/drake_iiwa_sim/include/drake_iiwa_sim/iiwa_qp_inverse_dynamics_controller.h
+++ b/src/catkin_projects/drake_iiwa_sim/include/drake_iiwa_sim/iiwa_qp_inverse_dynamics_controller.h
@@ -1,0 +1,59 @@
+#pragma once
+#include "drake_iiwa_sim/iiwa_lcm.h"
+
+#include <memory>
+#include <string>
+
+#include <drake/multibody/rigid_body_tree.h>
+#include <drake/systems/framework/leaf_system.h>
+
+namespace drake {
+namespace examples {
+namespace kuka_iiwa_arm {
+
+class IiwaQpInverseDynamicsController : public systems::LeafSystem<double> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(IiwaQpInverseDynamicsController)
+
+  IiwaQpInverseDynamicsController(std::unique_ptr<RigidBodyTree<double>> tree,
+                                  const Eigen::VectorXd& kp,
+                                  const Eigen::VectorXd& kd,
+                                  double control_period = 0.005);
+
+  const systems::OutputPort<double>& get_output_port_torque_commanded() const {
+    return this->get_output_port(0);
+  }
+
+  const systems::InputPortDescriptor<double>& get_input_port_estimated_state() const {
+    return this->get_input_port(0);
+  }
+
+  const systems::InputPortDescriptor<double>& get_input_port_state_reference() const {
+    return this->get_input_port(1);
+  }
+
+  const systems::InputPortDescriptor<double>& get_input_port_torque_reference() const {
+    return this->get_input_port(2);
+  }
+
+  void CopyStateOut(const systems::Context<double>& context,
+                    systems::BasicVector<double>* output) const {
+    output->SetFromVector(context.get_discrete_state(0).CopyToVector());
+  }
+
+  void DoCalcDiscreteVariableUpdates(
+      const systems::Context<double>& context,
+      const std::vector<const systems::DiscreteUpdateEvent<double>*>&,
+      systems::DiscreteValues<double>* discrete_state) const override;
+
+ private:
+  const double control_period_;  // in seconds
+  const int nq_ = kIiwaArmNumJoints;
+  Eigen::VectorXd kp_;
+  Eigen::VectorXd kd_;
+  std::unique_ptr<RigidBodyTreed> tree_{nullptr};
+};
+
+}  // namespace kuka_iiwa_arm
+}  // namespace examples
+}  // namespace drake

--- a/src/catkin_projects/drake_iiwa_sim/src/CMakeLists.txt
+++ b/src/catkin_projects/drake_iiwa_sim/src/CMakeLists.txt
@@ -30,21 +30,24 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+set(PROJECT_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/include/drake_iiwa_sim/)
 
-add_library(iiwa_lcm iiwa_lcm.cc)
+add_library(iiwa_lcm
+        ${PROJECT_INCLUDE_DIR}/iiwa_lcm.h
+        iiwa_lcm.cc)
 target_link_libraries(iiwa_lcm drake::drake)
 
 add_library(iiwa_qp_inverse_dynamics_controller
+        ${PROJECT_INCLUDE_DIR}/iiwa_qp_inverse_dynamics_controller.h
         iiwa_qp_inverse_dynamics_controller.cc)
-
 target_link_libraries(iiwa_qp_inverse_dynamics_controller drake::drake)
 
 add_executable(iiwa_sim kuka_simulation.cc)
-target_link_libraries(iiwa_sim 
-	iiwa_lcm 
-	iiwa_qp_inverse_dynamics_controller
-	drake::drake 
-	gflags_shared)
+target_link_libraries(iiwa_sim
+        iiwa_lcm
+        iiwa_qp_inverse_dynamics_controller
+        drake::drake
+        gflags_shared)
 
 # install library
 install(TARGETS iiwa_lcm

--- a/src/catkin_projects/drake_iiwa_sim/src/CMakeLists.txt
+++ b/src/catkin_projects/drake_iiwa_sim/src/CMakeLists.txt
@@ -47,7 +47,8 @@ target_link_libraries(iiwa_sim
 	gflags_shared)
 
 # install library
-install(TARGETS iiwa_lcm iiwa_qp_inverse_dynamics_controller
+install(TARGETS iiwa_lcm
+ iiwa_qp_inverse_dynamics_controller
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/src/catkin_projects/drake_iiwa_sim/src/CMakeLists.txt
+++ b/src/catkin_projects/drake_iiwa_sim/src/CMakeLists.txt
@@ -34,11 +34,20 @@
 add_library(iiwa_lcm iiwa_lcm.cc)
 target_link_libraries(iiwa_lcm drake::drake)
 
+add_library(iiwa_qp_inverse_dynamics_controller
+        iiwa_qp_inverse_dynamics_controller.cc)
+
+target_link_libraries(iiwa_qp_inverse_dynamics_controller drake::drake)
+
 add_executable(iiwa_sim kuka_simulation.cc)
-target_link_libraries(iiwa_sim iiwa_lcm drake::drake gflags_shared)
+target_link_libraries(iiwa_sim 
+	iiwa_lcm 
+	iiwa_qp_inverse_dynamics_controller
+	drake::drake 
+	gflags_shared)
 
 # install library
-install(TARGETS iiwa_lcm
+install(TARGETS iiwa_lcm iiwa_qp_inverse_dynamics_controller
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/src/catkin_projects/drake_iiwa_sim/src/iiwa_qp_inverse_dynamics_controller.cc
+++ b/src/catkin_projects/drake_iiwa_sim/src/iiwa_qp_inverse_dynamics_controller.cc
@@ -1,0 +1,86 @@
+#include "drake_iiwa_sim/iiwa_qp_inverse_dynamics_controller.h"
+
+#include <drake/solvers/mathematical_program.h>
+#include <drake/systems/framework/basic_vector.h>
+#include <drake/multibody/kinematics_cache.h>
+
+namespace drake {
+namespace examples {
+namespace kuka_iiwa_arm {
+
+typedef Eigen::Matrix<double, 7, 1> Vector7d;
+using Eigen::VectorXd;
+using Eigen::MatrixXd;
+using std::cout;
+using std::endl;
+
+IiwaQpInverseDynamicsController::IiwaQpInverseDynamicsController(
+    std::unique_ptr<RigidBodyTree<double>> tree, const VectorX<double>& kp,
+    const VectorX<double>& kd, double control_period)
+    : control_period_(control_period) {
+  // copy stuff.
+  tree_ = std::move(tree);
+  kp_ = kp;
+  kd_ = kd;
+
+  // declare ports and states.
+  this->DeclarePeriodicDiscreteUpdate(control_period_);
+  // estimated state input port
+  this->DeclareVectorInputPort(systems::BasicVector<double>(2 * nq_));
+  // reference state input port
+  this->DeclareVectorInputPort(systems::BasicVector<double>(2 * nq_));
+  // reference torque input port
+  this->DeclareVectorInputPort(systems::BasicVector<double>(nq_));
+  // commanded torque output port
+  this->DeclareVectorOutputPort(systems::BasicVector<double>(nq_),
+                                &IiwaQpInverseDynamicsController::CopyStateOut);
+  // the system's state is the commanded torque sent to rigid body plant.
+  this->DeclareDiscreteState(nq_);
+}
+
+void IiwaQpInverseDynamicsController::DoCalcDiscreteVariableUpdates(
+    const systems::Context<double>& context,
+    const std::vector<const systems::DiscreteUpdateEvent<double>*>&,
+    systems::DiscreteValues<double>* discrete_state) const {
+  // discrete state is the output (robot torque)
+  const VectorXd x = (*this->EvalVectorInput(
+                    context, get_input_port_estimated_state().get_index()))
+                   .CopyToVector();
+  const VectorXd x_ref = (*this->EvalVectorInput(
+                        context, get_input_port_state_reference().get_index()))
+                       .CopyToVector();
+  const VectorXd tau_ref =
+      (*this->EvalVectorInput(context,
+                              get_input_port_torque_reference().get_index()))
+          .CopyToVector();
+
+  const Vector7d q = x.head(nq_);
+  const Vector7d v = x.tail(nq_);
+  const Vector7d q_ref = x_ref.head(nq_);
+  const Vector7d v_ref = x_ref.tail(nq_);
+
+  // create tree alias, so that clion doesn't complain about unique pointers.
+  const RigidBodyTreed& tree = *tree_;
+  KinematicsCache<double> cache = tree.CreateKinematicsCache();
+  cache.initialize(q, v);
+  tree.doKinematics(cache, true);
+
+  MatrixXd H = tree.massMatrix(cache);
+  RigidBodyTree<double>::BodyToWrenchMap external_wrenches;
+
+  // desired acceleration
+  Vector7d err_q = q_ref - q;
+  Vector7d err_v = v_ref - v;
+  VectorXd vd_d = kp_.array() * err_q.array() + kd_.array() * err_v.array();
+  Vector7d tau = tree.inverseDynamics(cache, external_wrenches, vd_d);
+  
+
+  // const int idx_base = tree.FindBodyIndex("base");
+  // const int idx_ee = tree.FindBodyIndex("iiwa_link_ee");
+
+  discrete_state->get_mutable_vector().SetFromVector(tau);
+}
+
+}  // namespace kuka_iiwa_arm
+}  // namespace examples
+}  // namespace drake

--- a/src/catkin_projects/drake_iiwa_sim/src/kuka_simulation.cc
+++ b/src/catkin_projects/drake_iiwa_sim/src/kuka_simulation.cc
@@ -10,6 +10,7 @@
 #include <gflags/gflags.h>
 
 #include "drake_iiwa_sim/iiwa_lcm.h"
+#include "drake_iiwa_sim/iiwa_qp_inverse_dynamics_controller.h"
 
 #include <drake/common/drake_assert.h>
 #include <drake/common/find_resource.h>
@@ -20,6 +21,7 @@
 #include <drake/lcmt_iiwa_status.hpp>
 #include <drake/manipulation/util/sim_diagram_builder.h>
 #include <drake/multibody/parsers/urdf_parser.h>
+#include <drake/multibody/rigid_body_plant/drake_visualizer.h>
 #include <drake/multibody/rigid_body_plant/frame_visualizer.h>
 #include <drake/multibody/rigid_body_plant/rigid_body_plant.h>
 #include <drake/multibody/rigid_body_tree_construction.h>
@@ -53,13 +55,12 @@ using systems::FrameVisualizer;
 using systems::RigidBodyPlant;
 using systems::Simulator;
 
-void SetPositionControlledIiwaGains(Eigen::VectorXd* Kp,
-                                    Eigen::VectorXd* Ki,
+void SetPositionControlledIiwaGains(Eigen::VectorXd* Kp, Eigen::VectorXd* Ki,
                                     Eigen::VectorXd* Kd) {
   // All the gains are for acceleration, not directly responsible for generating
   // torques. These are set to high values to ensure good tracking. These gains
   // are picked arbitrarily.
-  Kp->resize(7);
+  Kp->resize(kIiwaArmNumJoints);
   *Kp << 100, 100, 100, 100, 100, 100, 100;
   Kd->resize(Kp->size());
   for (int i = 0; i < Kp->size(); i++) {
@@ -71,7 +72,7 @@ void SetPositionControlledIiwaGains(Eigen::VectorXd* Kp,
 
 int DoMain() {
   drake::lcm::DrakeLcm lcm;
-  SimDiagramBuilder<double> builder;
+  DiagramBuilder<double> builder;
 
   // Adds a plant.
   RigidBodyPlant<double>* plant = nullptr;
@@ -85,13 +86,14 @@ int DoMain() {
     parsers::urdf::AddModelInstanceFromUrdfFileToWorld(
         urdf, multibody::joints::kFixed, tree.get());
     multibody::AddFlatTerrainToWorld(tree.get(), 100., 10.);
-    plant = builder.AddPlant(std::move(tree));
+    plant = builder.template AddSystem<systems::RigidBodyPlant<double>>(
+        std::move(tree));
   }
-  // Creates and adds LCM publisher for visualization.
-  builder.AddVisualizer(&lcm);
-  builder.get_visualizer()->set_publish_period(kIiwaLcmStatusPeriod);
-
   const RigidBodyTree<double>& tree = plant->get_rigid_body_tree();
+
+  // Creates and adds LCM publisher for visualization.
+  auto vis = builder.template AddSystem<systems::DrakeVisualizer>(tree, &lcm);
+  vis->set_publish_period(kIiwaLcmStatusPeriod);
   const int num_joints = tree.get_num_positions();
 
   // Adds a iiwa controller
@@ -113,51 +115,55 @@ int DoMain() {
         iiwa_kd.head(kIiwaArmNumJoints);
   }
 
-  auto controller = builder.AddController<
-      systems::controllers::InverseDynamicsController<double>>(
-      RigidBodyTreeConstants::kFirstNonWorldModelInstanceId, tree.Clone(),
-      iiwa_kp, iiwa_ki, iiwa_kd, false /* without feedforward acceleration */);
+  auto controller = builder.template AddSystem<IiwaQpInverseDynamicsController>(
+      tree.Clone(), iiwa_kp, iiwa_kd);
 
   // Create the command subscriber and status publisher.
-  systems::DiagramBuilder<double>* base_builder = builder.get_mutable_builder();
-  auto command_sub = base_builder->AddSystem(
+  auto command_sub = builder.AddSystem(
       systems::lcm::LcmSubscriberSystem::Make<lcmt_iiwa_command>("IIWA_COMMAND",
                                                                  &lcm));
   command_sub->set_name("command_subscriber");
-  auto command_receiver =
-      base_builder->AddSystem<IiwaCommandReceiver>(num_joints);
+  auto command_receiver = builder.AddSystem<IiwaCommandReceiver>(num_joints);
   command_receiver->set_name("command_receiver");
-  std::vector<int> iiwa_instances =
-      {RigidBodyTreeConstants::kFirstNonWorldModelInstanceId};
+  std::vector<int> iiwa_instances = {
+      RigidBodyTreeConstants::kFirstNonWorldModelInstanceId};
   auto external_torque_converter =
-      base_builder->AddSystem<IiwaContactResultsToExternalTorque>(
-          tree, iiwa_instances);
-  auto status_pub = base_builder->AddSystem(
+      builder.AddSystem<IiwaContactResultsToExternalTorque>(tree,
+                                                            iiwa_instances);
+  auto status_pub = builder.AddSystem(
       systems::lcm::LcmPublisherSystem::Make<lcmt_iiwa_status>("IIWA_STATUS",
                                                                &lcm));
   status_pub->set_name("status_publisher");
   status_pub->set_publish_period(kIiwaLcmStatusPeriod);
-  auto status_sender = base_builder->AddSystem<IiwaStatusSender>(num_joints);
+  auto status_sender = builder.AddSystem<IiwaStatusSender>(num_joints);
   status_sender->set_name("status_sender");
 
-  base_builder->Connect(command_sub->get_output_port(),
-                        command_receiver->get_input_port(0));
-  base_builder->Connect(command_receiver->get_commanded_state_output_port(),
-                        controller->get_input_port_desired_state());
-  base_builder->Connect(plant->get_output_port(0),
-                        status_sender->get_state_input_port());
-  base_builder->Connect(command_receiver->get_output_port(0),
-                        status_sender->get_command_input_port());
-  base_builder->Connect(controller->get_output_port_control(),
-                        status_sender->get_commanded_torque_input_port());
-  base_builder->Connect(plant->torque_output_port(),
-                        status_sender->get_measured_torque_input_port());
-  base_builder->Connect(plant->contact_results_output_port(),
-                        external_torque_converter->get_input_port(0));
-  base_builder->Connect(external_torque_converter->get_output_port(0),
-                        status_sender->get_external_torque_input_port());
-  base_builder->Connect(status_sender->get_output_port(0),
-                        status_pub->get_input_port());
+  builder.Connect(command_sub->get_output_port(),
+                  command_receiver->get_input_port(0));
+  builder.Connect(command_receiver->get_commanded_state_output_port(),
+                  controller->get_input_port_state_reference());
+  builder.Connect(plant->get_output_port(0),
+                  status_sender->get_state_input_port());
+  builder.Connect(command_receiver->get_output_port(0),
+                  status_sender->get_command_input_port());
+  builder.Connect(controller->get_output_port_torque_commanded(),
+                  status_sender->get_commanded_torque_input_port());
+  builder.Connect(plant->torque_output_port(),
+                  status_sender->get_measured_torque_input_port());
+  builder.Connect(plant->contact_results_output_port(),
+                  external_torque_converter->get_input_port(0));
+  builder.Connect(external_torque_converter->get_output_port(0),
+                  status_sender->get_external_torque_input_port());
+  builder.Connect(status_sender->get_output_port(0),
+                  status_pub->get_input_port());
+  //-------------------
+  builder.Connect(plant->state_output_port(), vis->get_input_port(0));
+  builder.Connect(plant->state_output_port(),
+                  controller->get_input_port_estimated_state());
+  builder.Connect(command_receiver->get_commanded_torque_output_port(),
+                  controller->get_input_port_torque_reference());
+  builder.Connect(controller->get_output_port_torque_commanded(),
+                  plant->actuator_command_input_port());
 
   if (FLAGS_visualize_frames) {
     // TODO(sam.creasey) This try/catch block is here because even
@@ -167,7 +173,7 @@ int DoMain() {
     // happens (for example) when loading
     // dual_iiwa14_polytope_collision.urdf.
     try {
-    // Visualizes the end effector frame and 7th body's frame.
+      // Visualizes the end effector frame and 7th body's frame.
       std::vector<RigidBodyFrame<double>> local_transforms;
       local_transforms.push_back(
           RigidBodyFrame<double>("iiwa_link_ee", tree.FindBody("iiwa_link_ee"),
@@ -175,15 +181,15 @@ int DoMain() {
       local_transforms.push_back(
           RigidBodyFrame<double>("iiwa_link_7", tree.FindBody("iiwa_link_7"),
                                  Isometry3<double>::Identity()));
-      auto frame_viz = base_builder->AddSystem<systems::FrameVisualizer>(
+      auto frame_viz = builder.AddSystem<systems::FrameVisualizer>(
           &tree, local_transforms, &lcm);
-      base_builder->Connect(plant->get_output_port(0),
-                            frame_viz->get_input_port(0));
+      builder.Connect(plant->get_output_port(0), frame_viz->get_input_port(0));
       frame_viz->set_publish_period(kIiwaLcmStatusPeriod);
     } catch (std::logic_error& ex) {
-      drake::log()->error("Unable to visualize end effector frames:\n{}\n"
-                          "Maybe use --novisualize_frames?",
-                          ex.what());
+      drake::log()->error(
+          "Unable to visualize end effector frames:\n{}\n"
+          "Maybe use --novisualize_frames?",
+          ex.what());
       return 1;
     }
   }
@@ -203,6 +209,7 @@ int DoMain() {
       VectorX<double>::Zero(tree.get_num_positions()));
 
   // Simulate for a very long time.
+  simulator.get_mutable_integrator()->set_maximum_step_size(0.005);
   simulator.StepTo(FLAGS_simulation_sec);
 
   return 0;

--- a/src/catkin_projects/drake_iiwa_sim/src/kuka_simulation.cc
+++ b/src/catkin_projects/drake_iiwa_sim/src/kuka_simulation.cc
@@ -46,7 +46,6 @@ namespace drake {
 namespace examples {
 namespace kuka_iiwa_arm {
 namespace {
-using manipulation::util::SimDiagramBuilder;
 using systems::ConstantVectorSource;
 using systems::Context;
 using systems::Diagram;


### PR DESCRIPTION
The controller method which calculates torque input to the robot was buried under several layers of drake system inheritance. This PR 

- creates a custom controller system that exposes torque calculation
- allows the controller to take reference torque as an input (which is harder to do in drake's implementation)
- constructs `Diagram` without using `SimDiagramBuilder`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/spartan/309)
<!-- Reviewable:end -->
