### PR TITLE
Fix Hydra Teleop given new Schunk Driver upgrades

### DIFF
--- a/modules/spartan/manipulation/schunk_driver.py
+++ b/modules/spartan/manipulation/schunk_driver.py
@@ -86,14 +86,14 @@ class SchunkDriver(object):
     def sendCloseGripperCommand(self):
         return self.send_goal(self.closeGripperGoal)
 
-    def sendGripperCommand(self, width, force=40., speed=0.1, stop_on_block=False):
+    def sendGripperCommand(self, width, force=40., speed=0.1, stop_on_block=False, timeout=2.0):
         goal = wsg_50_common.msg.CommandGoal()
         goal.command.command_id = wsg_50_common.msg.Command.MOVE
         goal.command.width = width
         goal.command.speed = speed
         goal.command.force = force
         goal.command.stop_on_block = stop_on_block
-        return self.send_goal(goal)
+        return self.send_goal(goal, timeout=timeout)
 
     def gripper_has_object(self):
         """

--- a/scripts/bin/hydra_teleop.py
+++ b/scripts/bin/hydra_teleop.py
@@ -170,8 +170,6 @@ def do_main():
 
     handDriver = SchunkDriver()
     gripper_goal_pos = 0.1
-    handDriver.reset_and_home()
-    handDriver.reset_and_home()
 
     # Start by moving to an above-table pregrasp pose that we know
     # EE control will work well from (i.e. far from singularity)
@@ -254,7 +252,7 @@ def do_main():
                 last_gripper_update_time = time.time()
                 gripper_goal_pos += latest_hydra_msg.paddles[0].joy[0]*dt*0.05
                 gripper_goal_pos = max(min(gripper_goal_pos, 0.1), 0.0)
-                handDriver.sendGripperCommand(gripper_goal_pos, speed=0.1)
+                handDriver.sendGripperCommand(gripper_goal_pos, speed=0.1, timeout=0.01)
                 print "Gripper goal pos: ", gripper_goal_pos
                 br.sendTransform(origin_tf[0:3, 3],
                                  ro(transformations.quaternion_from_matrix(origin_tf)),


### PR DESCRIPTION
Adds a timeout argument to the sendGripperCommand so I can use it in an almost-nonblocking way in my Hydra Teleop script. (It's a bit of a cludge in this case -- I don't really want to invest more effort in a properly threaded teleop driver -- but having tweakable timeouts seem useful in general.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/spartan/342)
<!-- Reviewable:end -->
