### PR TITLE
Fixup Pybullet simulation to basic usability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,8 +268,8 @@ if (WITH_TRIMESH)
       message(FATAL_ERROR "Not using linux, don't know how to install v-hacd.")
     endif()
 
-    SET(TRIMESH_GIT_REPOSITORY git@github.com:gizatt/trimesh.git)
-    SET(TRIMESH_GIT_TAG 1f6d10850d5a1f667385f3776d0b9d71df92fac3)
+    SET(TRIMESH_GIT_REPOSITORY git@github.com:mikedh/trimesh.git)
+    SET(TRIMESH_GIT_TAG 2.35.15)
     # Installs our customized version of trimesh
     # to the project's site-packages build folder.
     # I use the setup.py to run the build step,

--- a/apps/iiwa/iiwa_hardware.pmd
+++ b/apps/iiwa/iiwa_hardware.pmd
@@ -5,7 +5,7 @@ group "0.sim" {
   }
 
   cmd "1a.pybullet_kuka_simulation_single_object" {
-    exec = "rosrun rlg_simulation pybullet_iiwa_rlg_simulation.py $SPARTAN_SOURCE_DIR/src/catkin_projects/rlg_simulation/config/iiwa_workstation_with_object.yaml";
+    exec = "rosrun rlg_simulation pybullet_iiwa_rlg_simulation.py $SPARTAN_SOURCE_DIR/src/catkin_projects/rlg_simulation/config/iiwa_workstation_with_object.yaml --headless";
     host = "localhost";
   }
   
@@ -31,6 +31,11 @@ group "0.sim" {
 
   cmd "5.state-translator-sim" {
     exec = "directorPython $SPARTAN_SOURCE_DIR/apps/iiwa/kuka_iiwa_state_translator.py --basePosition '0.0, 0.0, 0.7645, 0., 0., 0.'";
+    host = "localhost";
+  }
+
+  cmd "6.plan-runner-pybullet-sim" {
+    exec = "bash -c 'roslaunch drake_robot_control plan_runner.launch param_filename:=$(rospack find drake_robot_control)/config/iiwa_plan_runner_config_sim.yaml'";
     host = "localhost";
   }
 }
@@ -211,11 +216,16 @@ script "3.sim_pybullet_startup" {
     wait ms 2000;
     start cmd "0.LCM->ROS State Translator";
     start cmd "2.ROS-OpenNI-sim";
-    start cmd "1.plan-runner";
+    start cmd "6.plan-runner-pybullet-sim";
     start cmd "5.state-translator-sim";
-    start cmd "2.ROS Model and TF Publisher";
-    start cmd "3.rviz";
 
+    start cmd "2.ROS Model and TF Publisher";
+    start cmd "4.Robot Movement Service";
+    start cmd "5.IK Service";
+    start cmd "8.fusion_server";
+    
+    start cmd "3.rviz";
+    start cmd "4.director";
 }
 
 script "4.sim_pybullet_startup_for_ci" {
@@ -225,7 +235,7 @@ script "4.sim_pybullet_startup_for_ci" {
     wait ms 3000;
     start cmd "0.LCM->ROS State Translator";
     start cmd "2.ROS-OpenNI-sim";
-    start cmd "1.plan-runner";
+    start cmd "6.plan-runner-pybullet-sim";
     start cmd "5.state-translator-sim";
     start cmd "2.ROS Model and TF Publisher";
     start cmd "1.ROS Trajectory Server";

--- a/setup/docker/install_dependencies.sh
+++ b/setup/docker/install_dependencies.sh
@@ -18,7 +18,8 @@ apt install --no-install-recommends \
   dialog \
   python-pip \
   python-pytest \
-  libav-tools
+  libav-tools \
+  openscad
 
 # these following three are ElasticFusion dependencies
 apt install --no-install-recommends \
@@ -29,7 +30,6 @@ apt install --no-install-recommends \
 pip install --upgrade pip==9.0.3
 pip install -U setuptools
 
-# Dependencies of trimesh
 pip install \
   numpy \
   scipy \
@@ -38,4 +38,5 @@ pip install \
   plyfile \
   matplotlib==1.5.3 \
   scikit-image \
-  pytest-xdist
+  pytest-xdist \
+  vispy

--- a/src/catkin_projects/drake_robot_control/config/iiwa_plan_runner_config_sim.yaml
+++ b/src/catkin_projects/drake_robot_control/config/iiwa_plan_runner_config_sim.yaml
@@ -1,0 +1,13 @@
+lcm_status_channel: "IIWA_STATUS"
+lcm_command_channel: "IIWA_COMMAND"
+lcm_plan_channel: "COMMITTED_ROBOT_PLAN"
+lcm_stop_channel: "STOP"
+num_joints: 7
+robot_ee_body_name: "iiwa_link_ee"
+robot_urdf_path: "${SPARTAN_SOURCE_DIR}/drake/manipulation/models/iiwa_description/urdf/iiwa14_no_collision.urdf"
+joint_speed_limit_degree_per_sec: 30000000.0 # Very large, to account for slowdowns in the simulated robot.
+control_period_s: 0.005
+
+task_space_plan:
+  kp_rotation: [10, 10, 10] # orientation P gains
+  kp_translation: [5, 5, 5] # translation P gains

--- a/src/catkin_projects/drake_robot_control/launch/plan_runner.launch
+++ b/src/catkin_projects/drake_robot_control/launch/plan_runner.launch
@@ -2,7 +2,7 @@
 <launch>
 
 <arg name="pkg_name" default="drake_robot_control" />
-<arg name="param_filename" value="$(eval find(arg('pkg_name')) +'/config/iiwa_plan_runner_config.yaml')" />
+<arg name="param_filename" default="$(eval find(arg('pkg_name')) +'/config/iiwa_plan_runner_config.yaml')" />
 
 <node name="plan_runner" pkg="$(arg pkg_name)" type="plan_runner_node" output="screen">
     <param name="param_filename" type="string" value="$(arg param_filename)"/>


### PR DESCRIPTION
@jmcculloch2018 Might make your life easier.

I have longer-term plans in terms of upgrading our simulator, but this is a temporary stopgap to bring back a simulation that includes RGB-D sim. Primary changes are:

- Switch to a more reasonable Trimesh version.
- Launch the Pybullet sim headless, as it's much faster.
- Allow plan-runner to run with different configuration files, and supply a simulation configuration file that makes the plan-runner less sensitive to jumpy trajectories. (This is necessary as the rendering pass in the pybullet sim causes long enough delays to fault out the planrunner, making the robot impossible to drive.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/spartan/347)
<!-- Reviewable:end -->
