### PR TITLE
Fix bug in lookup_synchronized_image in fusion.py

### DIFF
--- a/src/catkin_projects/fusion_server/src/fusion_server/fusion.py
+++ b/src/catkin_projects/fusion_server/src/fusion_server/fusion.py
@@ -290,7 +290,7 @@ class ImageCapture(object):
 
         """
         idx = np.searchsorted(timestamps, query_time)
-        return min(idx, np.size(timestamps))
+        return min(idx, np.size(timestamps)-1)
 
 
 class FusionType:


### PR DESCRIPTION
This was a bug -- it can result in trying to index beyond the length of the array.

`-1` fixes it!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/spartan/368)
<!-- Reviewable:end -->
