### PR TITLE
Jenkins LCM logging + documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -216,34 +216,10 @@ Code Style
 - C++ code should follow the Google style guide https://google.github.io/styleguide/cppguide.html
 - Python code should follow the Google style guide https://github.com/google/styleguide/blob/gh-pages/pyguide.md
 
-
-CI with Jenkins
-============================
-CI is provided by Jenkins, presently running on a DRC laptop running Ubuntu
-16.04 with nvidia-375 and CUDA 8, plus docker and nvidia-docker. Two Jenkins jobs test
-our build:
-
-- A nightly-plus-whenever-it-is-updated build of the master branch. Master is tested by following the build-and-test routine described below.
-
-- A whenever-it-is-requested build of PR branches, which can be requested by including the phrase "Jenkins please test" in a comment on the PR. The branches are tested by merging them into master (if possible) and then following the build-and-test routine described below. For now, tests can only be demanded by `gizatt`, `manuelli`, and `peteflorence`. Anyone else can *request* a test, but one of those admins will have to confirm to Jenkins that the test can be run. This feature uses [this tool](https://github.com/jenkinsci/ghprb-plugin) under the hood, so admins can use the command `ok to test` to accept a PR for testing, and `add to whitelist` to add the author of the PR to the whitelist forever.
-
-Jenkins clones a completely fresh copy of the repository into a working directory,
-run `git submodule update --init`, and then runs::
-
-    python ${WORKSPACE}/setup/docker/docker_build.py
-    python ${WORKSPACE}/setup/docker/docker_run.py --entrypoint "/home/jenkins/spartan/setup/docker/run_jenkins.sh"
-
-
-If any step of this returns a nonzero error code, the build is considered failed.
-That includes failures in initializing any submodule; errors provisioning or
-launching a docker container; or errors detected by the `run_jenkins` script,
-which contains its own error checking on the CMake configuration and the build.
-Eventually, we'll be able to test a full simulation stack too!
-
-
 Other useful documentation
 ==========================
 - `Testing <doc/testing.md>`_
+- `CI with Jenkins <doc/jenkins.md>`_
 - `Camera Calibration <modules/spartan/calibration/README.md>`_
 - `Razer Hydra teleop guide <doc/hydra_guide.md>`_
 - `Schunk driving and usage guide <doc/schunk_driving_guide.md>`_

--- a/doc/jenkins.md
+++ b/doc/jenkins.md
@@ -1,5 +1,7 @@
-CI with Jenkins
-============================
+# CI with Jenkins
+
+## Overview
+
 CI is provided by Jenkins, presently running on a DRC laptop running Ubuntu
 16.04 with nvidia-418.56, CUDA 10, and nvidia-docker2. Three Jenkins jobs test
 our build:
@@ -22,8 +24,20 @@ launching a docker container; or errors detected by the `run_jenkins` script,
 which contains its own error checking on the CMake configuration and the build,
 as well as a battery of code tests.
 
-Developer's guide to Spartan-Jenkins
-==============================
+## Debugging failed builds
+
+Go to the Spartan build server interface by following the link that gets posted to Github, or by finding your build [here](http://spartan-jenkins.csail.mit.edu:8080/job/spartan-prs-merged/) and clicking on its build number. This results page contains all the information Jenkins saved about trying to build your PR (merged into master).
+
+### Did the build process itself fail?
+
+You can view the console output of the entire build by clicking on "Console Output" on the left-hand side of that overview page. Look at the bottom to see if the build completed and if tests ran. If the build didn't complete, find the error, diagnose it, try to reproduce it on your machine, and try again. Jenkins completely cleans out the workspace before each build, so maybe your error only shows up on clean builds.
+
+### Did a test fail?
+
+The output page links to test results, which include failures from the tests. The most common error at this point in time is "Never received full robot joint positions on /joint_states topic", which means, fairly uselessly, that the sim failed to start up for some reason. To help diagnose this error, each of the full-stack simulation tests runs with an LCM logger whose output is archived and accessible from the PR overview page. Download the LCM log and play it back (`lcm-logplayer` or `lcm-logplayer-gui`) with an observer procman open (`bot-procman-sheriff -o`) to get a hint as to what went wrong -- the LCM log includes a log of each process' printouts during the test, so look for critical processes that failed.
+
+
+# Developer's guide to Spartan-Jenkins
 
 The Spartan build server interface is available at http://spartan-jenkins.csail.mit.edu:8080/. Anyone can click around and view build logs. To tweak settings, a user must log in (button in the upper right). If you want permissions to do so, contact `gizatt` and I'll make you an account.
 

--- a/doc/jenkins.md
+++ b/doc/jenkins.md
@@ -1,0 +1,45 @@
+CI with Jenkins
+============================
+CI is provided by Jenkins, presently running on a DRC laptop running Ubuntu
+16.04 with nvidia-418.56, CUDA 10, and nvidia-docker2. Three Jenkins jobs test
+our build:
+
+- A nightly-plus-whenever-it-is-updated build of the master branch. Master is tested by following the build-and-test routine described below.
+
+- A nightly-plus-whenever-it-is-updated build of the master branch, rebased on upstream Drake, tested by following the build-and-test routine described below.
+
+- A whenever-it-is-requested build of PR branches, **which can be requested by including the phrase "Jenkins please test" in a comment on the PR**. The branches are tested by merging them into master (if possible) and then following the build-and-test routine described below. For now, tests can only be demanded by whitelists devs (`gizatt`, `manuelli`, `peteflorence`, and many others). Anyone else can *request* a test, but one of those admins will have to confirm to Jenkins that the test can be run. This feature uses [this tool](https://github.com/jenkinsci/ghprb-plugin) under the hood, so admins can use the command `ok to test` to accept a PR for testing, and `add to whitelist` to add the author of the PR to the whitelist forever.
+
+Jenkins clones a completely fresh copy of the repository into a working directory,
+run `git submodule update --init`, and then runs::
+
+    python ${WORKSPACE}/setup/docker/docker_build.py
+    python ${WORKSPACE}/setup/docker/docker_run.py --container "spartan-prs-merged" --no_udp --entrypoint "/home/jenkins/spartan/setup/docker/run_jenkins.sh"
+
+If any step of this returns a nonzero error code, the build is considered failed.
+That includes failures in initializing any submodule; errors provisioning or
+launching a docker container; or errors detected by the `run_jenkins` script,
+which contains its own error checking on the CMake configuration and the build,
+as well as a battery of code tests.
+
+Developer's guide to Spartan-Jenkins
+==============================
+
+The Spartan build server interface is available at http://spartan-jenkins.csail.mit.edu:8080/. Anyone can click around and view build logs. To tweak settings, a user must log in (button in the upper right). If you want permissions to do so, contact `gizatt` and I'll make you an account.
+
+## Tweaking build settings
+
+Click on any of the jobs (e.g. [`spartan-prs-merged`](http://spartan-jenkins.csail.mit.edu:8080/job/spartan-prs-merged/)) to get an overview of that job. On the left hand panel, you should see a "Configure" link that takes you to that job's control panel. (Remember to log in first.) E.g. [here](http://spartan-jenkins.csail.mit.edu:8080/job/spartan-prs-merged/configure) is the control panel for `spartan-prs-merged`. There is a ton of obscure settings in here -- the ones that you are most likely to need to update are:
+
+- **Adding devs to the whitelist:** under "Build Triggers", you'll see a box filled with whitelisted usernames. Add folks as desired, then save + apply the settings.
+- **Tweak the build command:** under "Build", there's a box that contains the magic bash commands used to actually invoke the build, including those `docker_build.py` and `docker_run.py` invocations listed above. Tweaking these lines tweaks what the build server does.
+
+Most things are self-explanatory. Jenkins has its own SSH keys and github account so it can hook into Spartan.
+
+## SSH access to spartan-jenkins
+
+The build server can be ssh'd into, but it only supports passwordless entry into the `locomotion` user. That means you need to follow [these](https://www.debian.org/devel/passwordlessssh) directions before you can SSH in: in short, append your SSH public key to the `~/.ssh/authorized_keys` file on Jenkins. You'll need to physically access Jenkins to do this.
+
+### How to poke around failed builds
+
+`sudo su jenkins` to become the `jenkins` user and then `cd ~/workspace`. The workspace for each job is in an appropriately named subfolder. Note that each job only has one workspace that gets cleared for each new build, so if you need to debug a build, it's probably wise to pause Jenkins. (Pause with the [`quietDown`](http://spartan-jenkins.csail.mit.edu:8080/quietDown) command, unpause with the [`cancelQuietDown`](http://spartan-jenkins.csail.mit.edu:8080/cancelQuietDown) command.)

--- a/modules/spartan/test/simulation_test.py
+++ b/modules/spartan/test/simulation_test.py
@@ -141,6 +141,11 @@ class IiwaSimulationTest(unittest.TestCase):
         :return:
         :rtype:
         """
+        logger = self._launch_process_and_test(
+            "[/usr/bin/env", "lcm-logger",
+            "${SPARTAN_SOURCE_DIR}/build/simulation_test_log_%s.lcm" % type(self).__name__)
+        self._all_processes.append(logger)
+
         deputy = self._launch_process_and_test(["/usr/bin/env", "bot-procman-deputy", "--name", "localhost"])
         self._all_processes.append(deputy)
         sheriff = self._launch_process_and_test(["/usr/bin/env", "bot-procman-sheriff",
@@ -150,7 +155,7 @@ class IiwaSimulationTest(unittest.TestCase):
 
         sheriff.wait()
         print "Sheriff returned code %d" % (sheriff.returncode)
-        assert sheriff.returncode == 0, "Sheriff returned code %d" %(sheriff.returncode)
+        self.assertEqual(sheriff.returncode, 0, "Sheriff returned code %d" %(sheriff.returncode))
 
 
     def _launch_process_and_test(self, args):
@@ -167,7 +172,7 @@ class IiwaSimulationTest(unittest.TestCase):
             # Process launched and terminated.
 
             process_name = ''.join(args)
-            assert p.returncode==0, "Process %s returned with nonzero code %d" %(process_name, p.returncode)
+            self.assertEqual(p.returncode, 0, "Process %s returned with nonzero code %d" %(process_name, p.returncode))
 
         return p
 

--- a/modules/spartan/test/simulation_test.py
+++ b/modules/spartan/test/simulation_test.py
@@ -142,8 +142,10 @@ class IiwaSimulationTest(unittest.TestCase):
         :rtype:
         """
         logger = self._launch_process_and_test(
-            "[/usr/bin/env", "lcm-logger",
-            "${SPARTAN_SOURCE_DIR}/build/simulation_test_log_%s.lcm" % type(self).__name__)
+            ["/usr/bin/env", "lcm-logger",
+            os.path.expandvars("${SPARTAN_SOURCE_DIR}/build/%s_%s.lcm" % (type(self).__name__, self._testMethodName))])
+        print("Logger start command: ", ["/usr/bin/env", "lcm-logger",
+            os.path.expandvars("${SPARTAN_SOURCE_DIR}/build/%s_%s.lcm" % (type(self).__name__, self._testMethodName))])
         self._all_processes.append(logger)
 
         deputy = self._launch_process_and_test(["/usr/bin/env", "bot-procman-deputy", "--name", "localhost"])

--- a/setup/docker/install_dependencies.sh
+++ b/setup/docker/install_dependencies.sh
@@ -39,4 +39,5 @@ pip install \
   matplotlib==1.5.3 \
   scikit-image \
   pytest-xdist \
-  vispy
+  vispy \
+  trimesh

--- a/setup/docker/run_jenkins.sh
+++ b/setup/docker/run_jenkins.sh
@@ -3,8 +3,8 @@
 use_ros
 
 cd ~/spartan
-rm -rf build
-mkdir build
+# rm -rf build
+# mkdir build
 cd build
 
 cmake -DWITH_PERCEPTION:BOOL=ON -DWITH_BULLET3:BOOL=ON -DWITH_TRIMESH:BOOL=OFF -DWITH_SCHUNK_DRIVER:BOOL=ON -DWITH_ROS:BOOL=ON -DWITH_REACHABILITY_ANALYZER:BOOL=OFF ..

--- a/setup/docker/run_jenkins.sh
+++ b/setup/docker/run_jenkins.sh
@@ -3,8 +3,8 @@
 use_ros
 
 cd ~/spartan
-# rm -rf build
-# mkdir build
+rm -rf build
+mkdir build
 cd build
 
 cmake -DWITH_PERCEPTION:BOOL=ON -DWITH_BULLET3:BOOL=ON -DWITH_TRIMESH:BOOL=OFF -DWITH_SCHUNK_DRIVER:BOOL=ON -DWITH_ROS:BOOL=ON -DWITH_REACHABILITY_ANALYZER:BOOL=OFF ..

--- a/setup/docker/run_jenkins.sh
+++ b/setup/docker/run_jenkins.sh
@@ -43,6 +43,11 @@ use_spartan
 # Launch a fake X-server in the background
 Xvfb :100 -screen 0 1280x1024x24 -ac +extension GLX +render -noreset &
 
+# Necessary to force downstream applications to use the
+# *mesa* libGL (rather than the default system libGL, which
+# doesn't seem to support GLX). May need to run in non-nvidia
+# docker for this to work.
+export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/mesa/libGL.so
 # Run Spartan modules test.
 # These tests *must* be run forked (as in, each test
 # in its own process)


### PR DESCRIPTION
PRing for test purposes. Gonna try to make Jenkins spit out LCM logs of its tests so it's possible to diagnose vertical sim test failures.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/spartan/376)
<!-- Reviewable:end -->
